### PR TITLE
Update debian/control

### DIFF
--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -6,6 +6,6 @@ Build-Depends: build-essential, cmake, debhelper (>= 7), inkscape, libqt5gui5, l
 Standards-Version: 4.1.1
 
 Package: coreboot-configurator
-Depends: nvramtool, ${shlibs:Depends}, ${misc:Depends}, libqt5gui5, qt5-style-plugins
+Depends: nvramtool, ${shlibs:Depends}, ${misc:Depends}, libqt5gui5, qt5-style-plugins, libyaml-cpp0.6
 Architecture: all
 Description: Graphical interface to change settings available in coreboot CBFS


### PR DESCRIPTION
Adding `libyaml-cpp0.6` dependency.

Note that this package is not present in Ubuntu 18.04 or Debian Stretch; these use `libyaml-cpp0.5v5` instead, which is a separate package (not a previous version of the same package), which is itself not present in the more recent releases. That means that this pull request effectively prevents this package from being installed on these earlier releases, unless `libyamml-cpp0.6` is added to the Star Labs PPA. 

This is is to close #1 