### PR TITLE
added dependencies list

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ sudo pamac remove coreboot-configurator
 ```
 
 ## Other Distributions
+##### Dependencies
+```
+c++ compiler (gcc)
+qt5
+yaml-cpp
+nvramtool
+meson
+```
+
 ##### Install
 ```
 git clone https://github.com/StarLabsLtd/coreboot-configurator.git


### PR DESCRIPTION
### List of dependencies
I have added a list of al of the dependencies needed for the coreboot-configurator app to function properly, this can come in handy for users trying to install the application on non-supported distros
#6 fixes this issue 
