### PR TITLE
Make the polkit policy match the cmd launched in src/application/MainWindow.cpp

### DIFF
--- a/src/resources/org.coreboot.reboot.policy
+++ b/src/resources/org.coreboot.reboot.policy
@@ -7,6 +7,6 @@
     <defaults>
       <allow_active>yes</allow_active>
     </defaults>
-    <annotate key="org.freedesktop.policykit.exec.path">/usr/sbin/reboot</annotate>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/systemctl reboot</annotate>
   </action>
 </policyconfig>


### PR DESCRIPTION
Make the polkit policy match the command launched in https://github.com/StarLabsLtd/coreboot-configurator/blob/944b575dc873c78627c352f9c1a1493981431a58/src/application/MainWindow.cpp#L322